### PR TITLE
gtav/michael: fix export typo

### DIFF
--- a/gtav/michael.lua
+++ b/gtav/michael.lua
@@ -1,5 +1,5 @@
 
-exports('GetMichaelbject', function()
+exports('GetMichaelObject', function()
     return Michael
 end)
 


### PR DESCRIPTION
I noticed the typo while browsing the source code. I regex searched other files for the same typo and didn't find anything else, so this should be fixed.