### PR TITLE
Update 2.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fix Holes In The Map (Updated to After Hours DLC)
+# Fix Holes In The Map (Updated to Diamond Casino DLC)
 
 The purpose of this script is to fix the holes in the map by loading zones that aren’t loaded by default. I’ve added quite a lot of places to load, based on [Mikeeh’s script](https://forum.fivem.net/t/release-load-unloaded-ipls/5911). If you just want to fix the holes in the map, then use this resource as provided.
 
@@ -45,6 +45,25 @@ This resource has been completely rewritten from scratch since v2.0. You can cus
 
 <details><summary>Click to view</summary>
 (DD/MM/YYYY)
+
+---
+
+19/07/2021 - 2.0.10
+- Added Diamond Casino IPLs: Casino, Garage, VIP garage, Penthouse
+- Import: Forced refresh of CEO Garages
+- Updated fxmanifest fx_version to cerulean
+- Updated IPL list link in fxmanifest nad removed outdated Props list and Interior ID list
+- Fixed export typo in `michael.lua`
+- Removed unnecessary space in north_yankton IPL
+
+27/05/2020 - 2.0.9a
+- Fixed disabling Pillbox Hospital
+- Fixed `ResetInteriorVariables`
+
+23/04/2020 - 2.0.9
+- Replaced deprecated __resource.lua with fxmanifest.lua
+- Added ferris wheel on the Del Perro Pier
+- Reformatted client.lua
 
 20/10/2019 - 2.0.8
 - Nightclubs: Added dry ice emitters

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,15 +1,13 @@
 -- Resources:
 -- **********
--- IPL list:			https://wiki.gt-mp.net/index.php/Online_Interiors_and_locations
--- Props list:			https://wiki.gt-mp.net/index.php/InteriorPropList
--- Interior ID list : 	https://wiki.gt-mp.net/index.php/InteriorIDList
+-- IPL list: https://wiki.rage.mp/index.php?title=Interiors_and_Locations
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 author 'Bob_74'
 description 'Load and customize your map'
-version '2.0.9a'
+version '2.0.10'
 
 client_scripts {
 	"lib/common.lua"
@@ -104,7 +102,7 @@ client_scripts {
 	-- DLC After Hours
 	, "dlc_afterhours/nightclubs.lua"
 	
-	-- DLC Diamond Casino
+	-- DLC Diamond Casino (Requires forced build 2060 or higher)
 	, "dlc_casino/casino.lua"
 	, "dlc_casino/penthouse.lua"
 }


### PR DESCRIPTION
- Updated version in fxmanifest
- Added README changelog for versions 2.0.9, 2.0.9a and 2.0.10
- Updated README title to say Updated to Diamond Casino DLC
- Replaced outdated IPL list with one that actually works
- Updated fx_version to cerulean
- Added note in fxmanifest to diamond casino DLC calls that mentions that the build 2060 or higher is required