### PR TITLE
feat(client): Disable Pillbox Hospital by default

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -26,7 +26,7 @@ Citizen.CreateThread(function()
     BahamaMamas.Enable(true)
 
     -- Pillbox hospital: 307.1680, -590.807, 43.280
-    PillboxHospital.Enable(true)
+    PillboxHospital.Enable(false)
 
     -- Zancudo Gates (GTAO like): -1600.30100000, 2806.73100000, 18.79683000
     ZancudoGates.LoadDefault()


### PR DESCRIPTION
This has been requested a lot in the QBCore Framework discord as lots of people want a 'custom' interior but it conflicts with the IPL, so I thought I'd do a Pull Request on this