### PR TITLE
Add coordinates for casino DLC

### DIFF
--- a/dlc_casino/casino.lua
+++ b/dlc_casino/casino.lua
@@ -21,6 +21,9 @@ DiamondCasino = {
         },
         Main = {
             ipl = "vw_casino_main",
+            
+            -- Normal Version: 1110.20, 216.60 -49.45
+            -- Heist Version: 2490.67, -280.40, -58.71
 
             Load = function()
                 EnableIpl(DiamondCasino.Ipl.Main.ipl, true)
@@ -31,6 +34,10 @@ DiamondCasino = {
         },
         Garage = {
             ipl = "vw_casino_garage",
+            
+            -- Loading Bay Garage: 2536.276, -278.98, -64.722
+            -- Vault Lobby: 2483.151, -278.58, -70.694
+            -- Vault: 2516.765, -238.056, -70.737
 
             Load = function()
                 EnableIpl(DiamondCasino.Ipl.Garage.ipl, true)
@@ -41,6 +48,9 @@ DiamondCasino = {
         },
         Carpark = {
             ipl = "vw_casino_carpark",
+            
+            -- Carpark Garage: 1380.000 200.000 -50.000
+            -- VIP Carpark Garage: 1295.000 230.000 -50.000
 
             Load = function()
                 EnableIpl(DiamondCasino.Ipl.Carpark.ipl, true)

--- a/dlc_casino/penthouse.lua
+++ b/dlc_casino/penthouse.lua
@@ -2,6 +2,8 @@ exports('GetDiamondPenthouseObject', function()
     return DiamondPenthouse
 end)
 
+-- Penthouse: 976.636 70.295 115.164
+
 DiamondPenthouse = {
     interiorId = 274689,
 


### PR DESCRIPTION
This PR includes some comments to the casino DLC files, which provide helpful coordinates for teleporting into either the freeroam or heist version of the diamond casino, as well as garages, penthouse, and the vault.