### PR TITLE
Fix train track near Davis Quartz

### DIFF
--- a/gtav/base.lua
+++ b/gtav/base.lua
@@ -97,4 +97,8 @@ Citizen.CreateThread(function()
 
     -- Ferris wheel
     RequestIpl("ferris_finale_anim")
+
+    -- Train track: 2626.374, 2949.869, 39.1409
+    RequestIpl("ld_rail_01_track")
+    RequestIpl("ld_rail_02_track")
 end)


### PR DESCRIPTION
Adds the missing train track near Davis Quartz.

Before/after:
![before](https://github.com/Bob74/bob74_ipl/assets/15322107/e18b0e58-5d04-4553-a117-cc4f459b5feb)
![after](https://github.com/Bob74/bob74_ipl/assets/15322107/cfe9b647-4bba-4004-8966-7417aa7a7229)
