### PR TITLE
Fix: Prevent entities from remaining loaded after being disabled and resource restarted

### DIFF
--- a/dlc_security/garage.lua
+++ b/dlc_security/garage.lua
@@ -53,6 +53,8 @@ MpSecurityGarage = {
             for entity, state in pairs(MpSecurityGarage.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityGarage.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityGarage.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_security/office1.lua
+++ b/dlc_security/office1.lua
@@ -85,6 +85,8 @@ MpSecurityOffice1 = {
             for entity, state in pairs(MpSecurityOffice1.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityOffice1.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityOffice1.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_security/office2.lua
+++ b/dlc_security/office2.lua
@@ -85,6 +85,8 @@ MpSecurityOffice2 = {
             for entity, state in pairs(MpSecurityOffice2.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityOffice2.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityOffice2.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_security/office3.lua
+++ b/dlc_security/office3.lua
@@ -84,6 +84,8 @@ MpSecurityOffice3 = {
             for entity, state in pairs(MpSecurityOffice3.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityOffice3.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityOffice3.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_security/office4.lua
+++ b/dlc_security/office4.lua
@@ -85,6 +85,8 @@ MpSecurityOffice4 = {
             for entity, state in pairs(MpSecurityOffice4.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityOffice4.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityOffice4.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_security/studio.lua
+++ b/dlc_security/studio.lua
@@ -40,6 +40,8 @@ MpSecurityStudio = {
             for entity, state in pairs(MpSecurityStudio.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(MpSecurityStudio.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(MpSecurityStudio.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_tuner/garage.lua
+++ b/dlc_tuner/garage.lua
@@ -73,6 +73,8 @@ TunerGarage = {
             for entity, state in pairs(TunerGarage.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(TunerGarage.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(TunerGarage.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_tuner/meetup.lua
+++ b/dlc_tuner/meetup.lua
@@ -44,6 +44,8 @@ TunerMeetup = {
             for entity, state in pairs(TunerMeetup.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(TunerMeetup.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(TunerMeetup.InteriorId, entity)
                 end
             end
         end,

--- a/dlc_tuner/methlab.lua
+++ b/dlc_tuner/methlab.lua
@@ -21,6 +21,8 @@ TunerMethLab = {
             for entity, state in pairs(TunerMethLab.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(TunerMethLab.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(TunerMethLab.InteriorId, entity)
                 end
             end
         end,

--- a/gta_mpsum2/simeonfix.lua
+++ b/gta_mpsum2/simeonfix.lua
@@ -34,6 +34,8 @@ CriminalEnterpriseSmeonFix = {
             for entity, state in pairs(CriminalEnterpriseSmeonFix.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(CriminalEnterpriseSmeonFix.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(CriminalEnterpriseSmeonFix.InteriorId, entity)
                 end
             end
         end,

--- a/gta_mpsum2/vehicle_warehouse.lua
+++ b/gta_mpsum2/vehicle_warehouse.lua
@@ -39,6 +39,8 @@ CriminalEnterpriseVehicleWarehouse = {
             for entity, state in pairs(CriminalEnterpriseVehicleWarehouse.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(CriminalEnterpriseVehicleWarehouse.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(CriminalEnterpriseVehicleWarehouse.InteriorId, entity)
                 end
             end
         end,

--- a/gta_mpsum2/warehouse.lua
+++ b/gta_mpsum2/warehouse.lua
@@ -39,6 +39,8 @@ CriminalEnterpriseWarehouse = {
             for entity, state in pairs(CriminalEnterpriseWarehouse.Entities) do
                 if type(entity) == 'string' and state then
                     ActivateInteriorEntitySet(CriminalEnterpriseWarehouse.InteriorId, entity)
+                elseif type(entity) == 'string' and not state then
+                    DeactivateInteriorEntitySet(CriminalEnterpriseWarehouse.InteriorId, entity)
                 end
             end
         end,


### PR DESCRIPTION
It's an edge use case if you wanted to see how different styles look like for a certain IPL.  
If you were to toggle an entity on (loading it into the server), then toggle it off, and then restart the resource, both versions would be loaded at the same time.

The current logic only checks if the entity is enabled and proceeds to load it, but it does account if the entity was already loaded and afterwards disabled in the configuration.  
With this fix, the `Load()` logic is correctly handled for these cases, ensuring entities are not duplicated after a resource restart.
